### PR TITLE
DRAFT: redesign - track cumulative borrows using a u64 counter instead of a bool flag

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -10,4 +10,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "mocha -t 1000000 tests/"
+test = "yarn mocha -t 1000000 tests/"

--- a/app/api.js
+++ b/app/api.js
@@ -153,14 +153,13 @@ function borrow(user, mint, amount) {
     // we could also have a client approval, and this would be my ideal design
     // but requiring a third instruction drastically reduces avail bytes for transaction proper
     // the new tx format might make this viable by cutting address repetition tho
-    let repayIxn = adobe.instruction.repay(new anchor.BN(amount), {
+    let repayIxn = adobe.instruction.repay({
         accounts: {
             user: user.publicKey,
             state: stateKey,
             pool: poolKey,
             poolToken: poolTokenKey,
             userToken: userTokenKey,
-            instructions: SYSVAR_INSTRUCTIONS_PUBKEY,
             tokenProgram: TOKEN_PROGRAM_ID,
     }});
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "type": "module",
     "dependencies": {
-        "@project-serum/anchor": "^0.17.0",
+        "@project-serum/anchor": "0.18.0",
         "@solana/spl-token": "^0.1.8"
     },
     "devDependencies": {

--- a/programs/evil/src/lib.rs
+++ b/programs/evil/src/lib.rs
@@ -1,5 +1,5 @@
+use adobe::cpi::accounts::{Borrow, Repay};
 use anchor_lang::prelude::*;
-use adobe::cpi::accounts::{ Borrow, Repay};
 
 declare_id!("5zAQ1XhjuHcQtUXJSTjbmyDagmKVHDMi5iADv5PfYEUK");
 
@@ -25,10 +25,10 @@ pub mod evil {
         Ok(())
     }
 
-    pub fn repay_proxy(ctx: Context<Adobe>, amount: u64) -> ProgramResult {
+    pub fn repay_proxy(ctx: Context<Adobe>) -> ProgramResult {
         msg!("evil repay_proxy");
 
-        adobe::cpi::repay(ctx.accounts.into_repay_context(), amount)?;
+        adobe::cpi::repay(ctx.accounts.into_repay_context())?;
 
         Ok(())
     }
@@ -72,7 +72,6 @@ impl<'info> Adobe<'info> {
                 pool: self.pool.clone(),
                 pool_token: self.pool_token.clone(),
                 user_token: self.user_token.clone(),
-                instructions: self.instructions.clone(),
                 token_program: self.token_program.clone(),
             },
         )

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@project-serum/anchor@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.17.0.tgz#99a2cc59cae2939c1db1197950b7b606319ea7a8"
-  integrity sha512-vctZHZD5rUP1WXUUaJFdKl+1u0dE+O2+jejmYcb0InAZiwXdGAW8mX47U902voT94PdCr0aNHuyOQ8I75nfinw==
+"@project-serum/anchor@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.18.0.tgz#867144282e59482230f797f73ee9f5634f846061"
+  integrity sha512-WTm+UB93MoxyCbjnHIibv/uUEoO/5gL4GEtE/aMioLF8Z4i0vCMPnvAN0xpk9VBu3t7ld2DcCE/L+6Z7dwU++w==
   dependencies:
     "@project-serum/borsh" "^0.2.2"
     "@solana/web3.js" "^1.17.0"


### PR DESCRIPTION
## Suggested Modifications:
- track borrows by saving the current borrowed amount in the pool account instead of using a boolean flag
- remove amount arg from repay; the instruction just repays the current borrowed amount saved in the pool account

This should enable safe CPI borrows and repays, including multiple borrows in the same tx. I haven't fully thought through if this change opens new vectors of attack but reducing user input should reduce attack surface.

Just a suggestion, feel free to disregard